### PR TITLE
Fix broken doc links and update Forklift paper URL

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,8 +20,8 @@ production as well.
 The main system implemented so far is a **single-node OpenLambda worker** that can take
 HTTP requests and invoke lambdas locally to compute responses.
 
-You can read more about the OpenLambda worker [here](https://github.com/open-lambda/open-lambda/blob/main/docs/worker.md)
-or just get started by [deploying a worker](https://github.com/open-lambda/open-lambda/blob/main/docs/quickstart.md).
+You can read more about the OpenLambda worker [here](https://github.com/open-lambda/open-lambda/blob/main/docs/worker/README.md)
+or just get started by [deploying a worker](https://github.com/open-lambda/open-lambda/blob/main/docs/worker/getting-started.md).
 
 ```{note}
 We are currently working on a **cluster mode**, where a pool of VMs running the worker
@@ -40,7 +40,7 @@ manually deploy workers yourself and put an HTTP load balancer in front of them.
 * - Title
   - Authors
   - Venue
-* - [**Forklift: Fitting Zygote Trees for Faster Package Initialization**](https://github.com/open-lambda/open-lambda)
+* - [**Forklift: Fitting Zygote Trees for Faster Package Initialization**](https://dl.acm.org/doi/10.1145/3702634.3702952)
   - Yang et al.
   - WoSC '24
 * - [**SOCK: Rapid Task Provisioning with Serverless-Optimized Containers**](https://www.usenix.org/conference/atc18/presentation/oakes)

--- a/worker.md
+++ b/worker.md
@@ -58,5 +58,5 @@ multi-node setups.
 
 ## Further Reading
 
-- [Quickstart guide](https://github.com/open-lambda/open-lambda/blob/main/docs/quickstart.md) — get a single worker running locally in minutes
+- [Quickstart guide](https://github.com/open-lambda/open-lambda/blob/main/docs/worker/getting-started.md) — get a single worker running locally in minutes
 - [SOCK: Rapid Task Provisioning with Serverless-Optimized Containers](https://www.usenix.org/conference/atc18/presentation/oakes) — the research paper describing the container backend.


### PR DESCRIPTION
## Summary
- Update worker/quickstart links from the now-missing `docs/worker.md` and `docs/quickstart.md` to their current locations under `docs/worker/` (`README.md` and `getting-started.md`).
- Point the Forklift paper entry to its ACM DOI (https://dl.acm.org/doi/10.1145/3702634.3702952) instead of the generic repo URL.

## Test plan
- [x] Verify the three updated links in `index.md` resolve to the correct pages on github.com
- [x] Verify the updated Quickstart link in `worker.md` resolves
- [x] Verify the Forklift DOI link opens the paper on dl.acm.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)